### PR TITLE
Fixed wallaby config

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-preset-es2015": "^6.18.0",
+    "jasmine": "^2.5.2",
     "jasmine-node": "^1.14.5"
   }
 }

--- a/wallaby.js
+++ b/wallaby.js
@@ -13,6 +13,7 @@ module.exports = function (wallaby) {
     ],
 
     compilers: {
+      '**/*.js': wallaby.compilers.babel()
     },
 
     testFramework: "jasmine",


### PR DESCRIPTION
Run `npm install` after merging (to install `jasmine`) and wallaby.js should work for you.